### PR TITLE
build(deps): bumps hadolint-alpine image to v1.18.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hadolint/hadolint:v1.17.5-alpine
+FROM hadolint/hadolint:v1.18.0-alpine
 
 COPY LICENSE README.md /
 


### PR DESCRIPTION
hadolint v1.18 is released: https://github.com/hadolint/hadolint/releases