### PR TITLE
Fix problem matcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hadolint/hadolint:v1.17.5-alpine
 
-COPY LICENSE README.md /
+COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh
 
 ENTRYPOINT [ "/usr/local/bin/hadolint.sh" ]

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
-echo '::add-matcher::problem-matcher.json'
+# The problem-matcher definition must be present in the repository
+# checkout (outside the Docker container running hadolint). We create
+# a temporary folder and copy problem-matcher.json to it and make it
+# readable.
+TMP_FOLDER=$(mktemp -d -p .)
+cp /problem-matcher.json "${TMP_FOLDER}"
+chmod -R a+rX "${TMP_FOLDER}"
+trap "rm -rf \"${TMP_FOLDER}\"" EXIT
+
+echo "::add-matcher::${TMP_FOLDER}/problem-matcher.json"
 
 hadolint "$@"


### PR DESCRIPTION
As mentioned in https://github.com/brpaz/hadolint-action/pull/10#issuecomment-739327662 the problem-matcher stuff didn't work because the definition is not present in the repository running the action.

An example of how it fails is: https://github.com/arnested/systemd-state/pull/54/checks?check_run_id=1504103163#step:4:6

This PR fixes the problem by adding the problem-matcher.json definition file to the Docker image and on runtime copying it into the repository.

An example of this PR doing its job and detecting and annotating errors can be seen here: https://github.com/arnested/systemd-state/pull/55/checks?check_run_id=1504185915#step:4:6

Sorry for the inconvenience, @brpaz.