### PR TITLE
Remove problem matcher after run

### DIFF
--- a/hadolint.sh
+++ b/hadolint.sh
@@ -7,7 +7,15 @@
 TMP_FOLDER=$(mktemp -d -p .)
 cp /problem-matcher.json "${TMP_FOLDER}"
 chmod -R a+rX "${TMP_FOLDER}"
-trap "rm -rf \"${TMP_FOLDER}\"" EXIT
+
+# After the run has finished we remove the problem-matcher.json from
+# the repository so we don't leave the checkout dirty. We also remove
+# the matcher so it won't take effect in later steps.
+cleanup() {
+    echo "::remove-matcher owner=brpaz/hadolint-action::"
+    rm -rf "${TMP_FOLDER}"
+}
+trap cleanup EXIT
 
 echo "::add-matcher::${TMP_FOLDER}/problem-matcher.json"
 

--- a/problem-matcher.json
+++ b/problem-matcher.json
@@ -1,7 +1,7 @@
 {
   "problemMatcher": [
     {
-      "owner": "hadolint",
+      "owner": "brpaz/hadolint-action",
       "pattern": [
         {
           "regexp": "(.*)\\:(\\d+)\\s(.*)",


### PR DESCRIPTION
Hopefully, the last PR with learnings from using problem matchers... They are a bit tricky after all...

When a problem matcher is added in one step it is having effect in subsequent steps as well. Not just the step adding it.

This came into effect when I had later step doing a `docker build` and some output lines matched the `hadolint` problem matcher pattern.

This pull request adds a `::remove-matcher` to the cleanup.